### PR TITLE
404 error resolved and other minor updates

### DIFF
--- a/_posts/2016-11-08-readium-js.md
+++ b/_posts/2016-11-08-readium-js.md
@@ -3,7 +3,7 @@ layout: post
 title:  "Overview of Readium JS"
 date:   2016-11-08 13:30:00 +0100
 categories: overview
-permalink: /readium-js/
+permalink: /readium-js-overview/
 ---
 
 Readium JS comprises two sub-projects, Readium Chrome Extension and the Readium CloudReader. Both consist of three major pieces:

--- a/_posts/2016-11-08-readium-lcp.md
+++ b/_posts/2016-11-08-readium-lcp.md
@@ -3,7 +3,7 @@ layout: post
 title:  "Overview of Readium LCP"
 date:   2016-11-08 13:30:00 +0100
 categories: overview
-permalink: /readium-lcp/
+permalink: /readium-lcp-overview/
 ---
 
 ## Introduction

--- a/_posts/2016-11-08-readium-sdk.md
+++ b/_posts/2016-11-08-readium-sdk.md
@@ -3,7 +3,7 @@ layout: post
 title:  "Overview of Readium SDK"
 date:   2016-12-28 11:30:00 +0100
 categories: overview
-permalink: /readium-sdk/
+permalink: /readium-sdk-overview/
 ---
 
 Readium SDK consists of three major parts:

--- a/_posts/2016-11-15-lcp-specs-codebase.md
+++ b/_posts/2016-11-15-lcp-specs-codebase.md
@@ -3,7 +3,7 @@ layout: post
 title:  "Readium LCP Specs and Codebase"
 date:   2016-11-15 11:30:00 +0100
 categories: specifications
-permalink: /lcp-specs-codebase/
+permalink: /readium-lcp-specifications-codebase/
 ---
 
 Readium LCP (“Licensed Content Protection”) establishes a vendor-neutral interoperable DRM (Digital Rights Management) ecosystem for eBooks and other digital publications, with public specifications and open-source software. 

--- a/_posts/2016-11-15-lsd-specification.md
+++ b/_posts/2016-11-15-lsd-specification.md
@@ -190,6 +190,7 @@ This is the default value if the License Document does not contain a registratio
     <td>The license is no longer active because it has expired.</td>
   </tr>
 </table>
+
 ### 2.4. Timestamps
 
 A Status Document <b>MUST</b> include an `updated` object where the following keys and associated timestamps are provided:

--- a/table-of-contents.md
+++ b/table-of-contents.md
@@ -8,12 +8,12 @@ permalink: /table-of-contents/
 - [A Bit Of History](/history/)
 - [Applications Based on Readium](/applications/)
 - Readium JS
-    - [Overview](/readium-js/)
+    - [Overview](/readium-js-overview/)
 - Readium SDK
-    - [Overview](/readium-sdk/)
+    - [Overview](/readium-sdk-overview/)
 - Readium LCP
-    - [Overview](/readium-lcp/)
-    - [Specs and codebase](/lcp-specs-codebase/)
+    - [Overview](/readium-lcp-overview/)
+    - [Specs and codebase](/readium-lcp-specifications-codebase/)
         - [Readium Licensed Content Protection Specification 1.0](/readium-lcp-specification/)
         - [Readium License Status Document  Specification 1.0](/readium-lsd-specification/)
 - [Releases](/releases/)


### PR DESCRIPTION
Solves a 404 error on access to the readium sdk overview page, plus some permalink updates to avoid other potential clashes, plus correction of a typo on the lsd specification (a ### 2.4 title appeared on the website, but not locally).

More info:  we wrote a post in the Organization Pages
https://github.com/readium/readium.github.io/blob/master/_posts/2016-11-08-readium-sdk.md
with a permalink /readium-sdk/
which ends up with the URL https://readium.github.io/readium-sdk/

but there is also a Project repo named readium-sdk, and the system must give a priority to its gh-pages (= Project Pages). But there is no such pages. 

Therefore I changed some permalinks of the Organization Pages ... 